### PR TITLE
feat: WB-3821, enabling content transformer client to request a set of app-specific additional content transformations

### DIFF
--- a/src/main/java/fr/wseduc/transformer/to/ContentTransformerRequest.java
+++ b/src/main/java/fr/wseduc/transformer/to/ContentTransformerRequest.java
@@ -63,11 +63,7 @@ public class ContentTransformerRequest {
      * @param htmlContent html content to transform into json
      * @param jsonContent json content to transform into html
      */
-    @JsonCreator
-    public ContentTransformerRequest(@JsonProperty("requestedFormats") Set<ContentTransformerFormat> requestedFormats,
-                                     @JsonProperty("contentVersion") int contentVersion,
-                                     @JsonProperty("htmlContent") String htmlContent,
-                                     @JsonProperty("jsonContent") JsonObject jsonContent) {
+    public ContentTransformerRequest(Set<ContentTransformerFormat> requestedFormats, int contentVersion, String htmlContent, JsonObject jsonContent) {
         this(requestedFormats, contentVersion, htmlContent, jsonContent, Collections.emptySet());
     }
 

--- a/src/main/java/fr/wseduc/transformer/to/ContentTransformerRequest.java
+++ b/src/main/java/fr/wseduc/transformer/to/ContentTransformerRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -29,9 +30,34 @@ public class ContentTransformerRequest {
      * Json content to transform into html
      */
     private final JsonObject jsonContent;
+    /**
+     * Ids of additional extensions to be applied by the content transformer
+     */
+    private final Set<String> additionalExtensionIds;
 
     /**
      * Constructor
+     * @param requestedFormats requested transformation formats
+     * @param contentVersion version of content to transform
+     * @param htmlContent html content to transform into json
+     * @param jsonContent json content to transform into html
+     * @param additionalExtensionIds ids of additional extensions
+     */
+    @JsonCreator
+    public ContentTransformerRequest(@JsonProperty("requestedFormats") Set<ContentTransformerFormat> requestedFormats,
+                                     @JsonProperty("contentVersion") int contentVersion,
+                                     @JsonProperty("htmlContent") String htmlContent,
+                                     @JsonProperty("jsonContent") JsonObject jsonContent,
+                                     @JsonProperty("additionalExtensionIds") Set<String> additionalExtensionIds) {
+        this.requestedFormats = requestedFormats;
+        this.contentVersion = contentVersion;
+        this.htmlContent = htmlContent;
+        this.jsonContent = jsonContent;
+        this.additionalExtensionIds = additionalExtensionIds;
+    }
+
+    /**
+     * Constructor with empty additionalExtensionIds
      * @param requestedFormats requested transformation formats
      * @param contentVersion version of content to transform
      * @param htmlContent html content to transform into json
@@ -42,10 +68,7 @@ public class ContentTransformerRequest {
                                      @JsonProperty("contentVersion") int contentVersion,
                                      @JsonProperty("htmlContent") String htmlContent,
                                      @JsonProperty("jsonContent") JsonObject jsonContent) {
-        this.requestedFormats = requestedFormats;
-        this.contentVersion = contentVersion;
-        this.htmlContent = htmlContent;
-        this.jsonContent =jsonContent;
+        this(requestedFormats, contentVersion, htmlContent, jsonContent, Collections.emptySet());
     }
 
     public Set<ContentTransformerFormat> getRequestedFormats() {
@@ -62,6 +85,10 @@ public class ContentTransformerRequest {
 
     public JsonObject getJsonContent() {
         return jsonContent;
+    }
+
+    public Set<String> getAdditionalExtensionIds() {
+        return additionalExtensionIds;
     }
 }
 


### PR DESCRIPTION
This enables content transformer client to specify a set of additional plugins to be applied by content transformer.
This is retro-compatible, with previous content transformation requests (blog, wiki...)

Related PR : 
- https://github.com/edificeio/edifice-tiptap-transformer/pull/21
- https://github.com/edificeio/entcore/pull/587