### PR TITLE
Fix coco 4672 template processor race condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>fr.wseduc</groupId>
     <artifactId>web-utils</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.2-develop-b2school-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/fr/wseduc/webutils/http/ProcessTemplateContext.java
+++ b/src/main/java/fr/wseduc/webutils/http/ProcessTemplateContext.java
@@ -9,51 +9,82 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Container for all parameters needed for the template processinf
+ * Container for all parameters needed for the template processing
  */
-public class ProcessTemplateContext {
+public final class ProcessTemplateContext {
 
-    private HttpServerRequest request;
-    private JsonObject params;
-    private String templateString;
-    private Reader reader;
-    private boolean escapeHtml;
-    private String defaultValue;
-    private final Map<String, Mustache.Lambda> lambdas = new HashMap<>();
+    private final HttpServerRequest request;
+    private final JsonObject params;
+    private final String templateString;
+    private final Reader reader;
+    private final boolean escapeHtml;
+    private final String defaultValue;
+    private final Map<String, Mustache.Lambda> lambdas;
 
-    public ProcessTemplateContext request(HttpServerRequest request) {
+    private ProcessTemplateContext(HttpServerRequest request, JsonObject params, String templateString, Reader reader,
+                                  boolean escapeHtml, String defaultValue, Map<String, Mustache.Lambda> lambdas) {
         this.request = request;
-        return this;
-    }
-
-    public ProcessTemplateContext escapeHtml(boolean escapeHtml) {
-        this.escapeHtml = escapeHtml;
-        return this;
-    }
-
-    public ProcessTemplateContext setDefaultValue(String defaultValue) {
-        this.defaultValue = defaultValue;
-        return this;
-    }
-
-    public ProcessTemplateContext params(JsonObject params) {
         this.params = params;
-        return this;
-    }
-
-    public ProcessTemplateContext templateString(String templateString) {
         this.templateString = templateString;
-        return this;
-    }
-
-    public ProcessTemplateContext reader(Reader reader) {
         this.reader = reader;
-        return this;
+        this.escapeHtml = escapeHtml;
+        this.defaultValue = defaultValue;
+        this.lambdas = new HashMap<>(lambdas);
     }
 
-    public ProcessTemplateContext lambdas(Map<String, Mustache.Lambda> lambdas) {
-        this.lambdas.putAll(lambdas);
-        return this;
+    public static class Builder {
+
+        private HttpServerRequest request;
+        private JsonObject params;
+        private String templateString;
+        private Reader reader;
+        private boolean escapeHtml;
+        private String defaultValue;
+        private final Map<String, Mustache.Lambda> lambdas = new HashMap<>();
+
+        public Builder request(HttpServerRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder escapeHtml(boolean escapeHtml) {
+            this.escapeHtml = escapeHtml;
+            return this;
+        }
+
+        public Builder setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder params(JsonObject params) {
+            this.params = params;
+            return this;
+        }
+
+        public Builder templateString(String templateString) {
+            this.templateString = templateString;
+            return this;
+        }
+
+        public Builder reader(Reader reader) {
+            this.reader = reader;
+            return this;
+        }
+
+        public Builder lambdas(Map<String, Mustache.Lambda> lambdas) {
+            this.lambdas.putAll(lambdas);
+            return this;
+        }
+
+        public HttpServerRequest request() {
+            return request;
+        }
+
+        public ProcessTemplateContext build() {
+            return new ProcessTemplateContext(request, params, templateString, reader, escapeHtml, defaultValue, lambdas);
+        }
+
     }
 
     public HttpServerRequest request() {

--- a/src/main/java/fr/wseduc/webutils/http/ProcessTemplateContext.java
+++ b/src/main/java/fr/wseduc/webutils/http/ProcessTemplateContext.java
@@ -1,0 +1,86 @@
+package fr.wseduc.webutils.http;
+
+import com.samskivert.mustache.Mustache;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Container for all parameters needed for the template processinf
+ */
+public class ProcessTemplateContext {
+
+    private HttpServerRequest request;
+    private JsonObject params;
+    private String templateString;
+    private Reader reader;
+    private boolean escapeHtml;
+    private String defaultValue;
+    private final Map<String, Mustache.Lambda> lambdas = new HashMap<>();
+
+    public ProcessTemplateContext request(HttpServerRequest request) {
+        this.request = request;
+        return this;
+    }
+
+    public ProcessTemplateContext escapeHtml(boolean escapeHtml) {
+        this.escapeHtml = escapeHtml;
+        return this;
+    }
+
+    public ProcessTemplateContext setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    public ProcessTemplateContext params(JsonObject params) {
+        this.params = params;
+        return this;
+    }
+
+    public ProcessTemplateContext templateString(String templateString) {
+        this.templateString = templateString;
+        return this;
+    }
+
+    public ProcessTemplateContext reader(Reader reader) {
+        this.reader = reader;
+        return this;
+    }
+
+    public ProcessTemplateContext lambdas(Map<String, Mustache.Lambda> lambdas) {
+        this.lambdas.putAll(lambdas);
+        return this;
+    }
+
+    public HttpServerRequest request() {
+        return request;
+    }
+
+    public JsonObject params() {
+        return params;
+    }
+
+    public String templateString() {
+        return templateString;
+    }
+
+    public Reader reader() {
+        return reader;
+    }
+
+    public Map<String, Mustache.Lambda> lambdas() {
+        return lambdas;
+    }
+
+    public boolean escapeHtml() {
+        return escapeHtml;
+    }
+
+    public String defaultValue() {
+        return defaultValue;
+    }
+}

--- a/src/main/java/fr/wseduc/webutils/http/Renders.java
+++ b/src/main/java/fr/wseduc/webutils/http/Renders.java
@@ -33,6 +33,7 @@ import fr.wseduc.webutils.template.lambdas.InfraLambda;
 import fr.wseduc.webutils.template.lambdas.LocaleDateLambda;
 import fr.wseduc.webutils.template.lambdas.ModsLambda;
 import fr.wseduc.webutils.template.lambdas.StaticLambda;
+import io.micrometer.common.util.StringUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -50,6 +51,12 @@ import fr.wseduc.webutils.Server;
 
 import static fr.wseduc.webutils.Utils.isNotEmpty;
 
+/**
+ * Method with @deprecated, relative to template processing are NOT thread safe and should not be used. Alternative method not deprecated was developed.
+ * Lambda for template processing dependent of the user context (request, host, etc..) must not be shared and are local variable.
+ * Static lambda that doesn't change with the context can be used
+ * Parameter for the template are either NOT thread safe. EscapeHTML, defaultValue, should be passed as local variable
+ */
 public class Renders {
 
 	protected static final Logger log = LoggerFactory.getLogger(Renders.class);
@@ -112,10 +119,79 @@ public class Renders {
 		this.templateProcessor.setLambda("datetime", new LocaleDateLambda(I18n.acceptLanguage(request)));
 	}
 
-	protected Map<String, Mustache.Lambda> getLambdasFromRequest() {
-		return null;
+	protected Map<String, Mustache.Lambda> getLambdasFromRequest(final HttpServerRequest request) {
+		Map<String, Mustache.Lambda> lambdas = new HashMap<>();
+
+		String host = Renders.getHost(request);
+		if(host == null) // This can happen for forged requests
+			host = "";
+		String sttcHost = this.staticHost != null ? this.staticHost : host;
+
+
+		lambdas.put("i18n",
+				new I18nLambda(I18n.acceptLanguage(request), host, I18n.getTheme(request)));
+		lambdas.put("static",
+				new StaticLambda(config.getBoolean("ssl", sttcHost.startsWith("https")), sttcHost, this.pathPrefix + "/public"));
+		lambdas.put("infra",
+				new InfraLambda(config.getBoolean("ssl", sttcHost.startsWith("https")), sttcHost, "/infra/public", request.headers().get("X-Forwarded-For") == null));
+		lambdas.put("datetime", new LocaleDateLambda(I18n.acceptLanguage(request)));
+		return lambdas;
 	}
 
+	public void renderTemplateView(HttpServerRequest request) {
+		renderTemplateView(request, new JsonObject(), new HashMap<>());
+	}
+
+	public void renderTemplateView(HttpServerRequest request, Map<String, Mustache.Lambda> lambdas) {
+		renderTemplateView(request, new JsonObject(), lambdas);
+	}
+
+	public void renderTemplateView(HttpServerRequest request, JsonObject params) {
+		renderTemplateView(request, params, new HashMap<>());
+	}
+
+	public void renderTemplateView(HttpServerRequest request, JsonObject params, Map<String, Mustache.Lambda> lambdas) {
+		renderTemplateView(request, params, null, null, 200, lambdas);
+	}
+
+	public void renderTemplateView(HttpServerRequest request, JsonObject params,  String resourceName,
+								   Reader r, Map<String, Mustache.Lambda> lambdas) {
+		renderTemplateView(request, params, resourceName, r, 200, lambdas);
+	}
+
+	public void renderTemplateView(final HttpServerRequest request, JsonObject params,
+								   String resourceName, Reader r, final int status, Map<String, Mustache.Lambda> lambdas) {
+
+		Map<String, Mustache.Lambda> mergeLambdas = getLambdasFromRequest(request);
+		mergeLambdas.putAll(lambdas);
+		mergeLambdas.putAll(staticLambdas);
+
+		ProcessTemplateContext context = new ProcessTemplateContext()
+												.escapeHtml(true)
+												.reader(r)
+												.lambdas( mergeLambdas)
+												.request(request);
+		processTemplateWithLambdas(context,  resourceName,writer -> {
+			if (writer != null) {
+				request.response().putHeader("content-type", "text/html; charset=utf-8");
+				request.response().setStatusCode(status);
+				if (hookRenderProcess != null) {
+					executeHandlersHookRender(request, new Handler<Void>() {
+						@Override
+						public void handle(Void v) {
+							request.response().end(writer.toString());
+						}
+					});
+				} else {
+					request.response().end(writer.toString());
+				}
+			} else {
+				renderError(request);
+			}
+		});
+	}
+
+	@Deprecated
 	public void renderView(HttpServerRequest request) {
 		renderView(request, new JsonObject());
 	}
@@ -124,14 +200,17 @@ public class Renders {
 	 * Render a Mustache template : see http://mustache.github.com/mustache.5.html
 	 * TODO : isolate scope management
 	 */
+	@Deprecated
 	public void renderView(HttpServerRequest request, JsonObject params) {
 		renderView(request, params, null, null, 200);
 	}
 
+	@Deprecated
 	public void renderView(HttpServerRequest request, JsonObject params, String resourceName, Reader r) {
 		renderView(request, params, resourceName, r, 200);
 	}
 
+	@Deprecated
 	public void renderView(final HttpServerRequest request, JsonObject params,
 			String resourceName, Reader r, final int status) {
 		processTemplate(request, params, resourceName, r, new Handler<Writer>() {
@@ -173,12 +252,14 @@ public class Renders {
 		handlers[0].handle(null);
 	}
 
+	@Deprecated
 	public void processTemplate(HttpServerRequest request, String template, JsonObject params, final Handler<String> handler)
 	{
 		this.setLambdaTemplateRequest(request);
 		this.templateProcessor.escapeHTML(true).processTemplate(this.genTemplateName(template, request), params, handler);
 	}
 
+	@Deprecated
 	public void processTemplate(final HttpServerRequest request, JsonObject p, String resourceName, Reader r, final Handler<Writer> handler)
 	{
 		this.setLambdaTemplateRequest(request);
@@ -186,24 +267,33 @@ public class Renders {
 		this.templateProcessor.processTemplate(this.genTemplateName(resourceName, request), p, r, handler);
 	}
 
+	@Deprecated
 	public void processTemplate(final HttpServerRequest request, JsonObject p, String resourceName, boolean escapeHTML, final Handler<String> handler)
 	{
 		this.setLambdaTemplateRequest(request);
 		this.templateProcessor.escapeHTML(escapeHTML).processTemplate(this.genTemplateName(resourceName, request), p, handler);
 	}
 
-	private String genTemplateName(final String resourceName, final HttpServerRequest request)
-	{
-		if (resourceName != null && !resourceName.trim().isEmpty())
+	public void processTemplateWithLambdas(ProcessTemplateContext context, Handler<Writer> handler) {
+		context.lambdas(getLambdasFromRequest(context.request()));
+		this.templateProcessor.processTemplate(context, handler);
+	}
+
+	public void processTemplateWithLambdas(ProcessTemplateContext context, String resourceName, Handler<Writer> handler) {
+		context.lambdas(getLambdasFromRequest(context.request()));
+		context.templateString(genTemplateName(resourceName, context.request()));
+		this.templateProcessor.processTemplate(context, handler);
+	}
+
+	private String genTemplateName(final String resourceName, final HttpServerRequest request) {
+		if (!StringUtils.isEmpty(resourceName)) {
 			return resourceName;
-		else
-		{
-			String template = request.path().substring(pathPrefix.length());
-			if (template.trim().isEmpty()) {
-				template = pathPrefix.substring(1);
-			}
-			return template + ".html";
 		}
+		String template = request.path().substring(pathPrefix.length());
+		if (template.trim().isEmpty()) {
+			template = pathPrefix.substring(1);
+		}
+		return template + ".html";
 	}
 
 	public static void ok(HttpServerRequest request) {

--- a/src/main/java/fr/wseduc/webutils/security/SecuredAction.java
+++ b/src/main/java/fr/wseduc/webutils/security/SecuredAction.java
@@ -30,6 +30,14 @@ public class SecuredAction {
         this.right = right;
     }
 
+	public SecuredAction(String qualifiedName, String displayName, String type) {
+		this.name = qualifiedName;
+		this.displayName = displayName;
+		this.type = type;
+		this.right = qualifiedName;
+	}
+
+
 	public String getName() {
 		return name;
 	}

--- a/src/main/java/fr/wseduc/webutils/template/TemplateProcessor.java
+++ b/src/main/java/fr/wseduc/webutils/template/TemplateProcessor.java
@@ -21,34 +21,24 @@ package fr.wseduc.webutils.template;
 
 import java.io.Writer;
 import java.io.StringWriter;
-import java.io.Reader;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import fr.wseduc.webutils.collections.JsonUtils;
-import io.vertx.core.AsyncResult;
+import fr.wseduc.webutils.http.ProcessTemplateContext;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
-import static fr.wseduc.webutils.data.FileResolver.absolutePath;
 
 public class TemplateProcessor
 {
   protected static final Logger log = LoggerFactory.getLogger(TemplateProcessor.class);
 
   protected Mustache.Compiler compiler = Mustache.compiler().defaultValue("");
-  private Map<String, Mustache.Lambda> templateLambdas = new ConcurrentHashMap<String, Mustache.Lambda>();
-
-  public TemplateProcessor()
-  {
-  }
+  private Map<String, Mustache.Lambda> templateLambdas = new ConcurrentHashMap<>();
 
   // =========================================== COMPILER CONFIGURATION ===========================================
 
@@ -66,12 +56,14 @@ public class TemplateProcessor
     return this;
   }
 
+  @Deprecated
   public TemplateProcessor defaultValue(String defaultValue)
   {
     this.compiler = this.compiler.defaultValue(defaultValue);
     return this;
   }
 
+  @Deprecated
   public TemplateProcessor escapeHTML(boolean enableHTMLEscaping)
   {
     this.compiler = this.compiler.escapeHTML(enableHTMLEscaping);
@@ -84,60 +76,13 @@ public class TemplateProcessor
   @Deprecated
   public void processTemplate(String templateString, JsonObject params, final Handler<String> handler)
   {
-    this.processTemplateToWriter(templateString, params, new Handler<Writer>()
-    {
-      @Override
-      public void handle(Writer w)
-      {
-        handler.handle(w == null ? null : w.toString());
-      }
-    });
-  }
-
-  public void processTemplate(String templateString, JsonObject params, Map<String, Mustache.Lambda> lambdas,
-                              final Handler<String> handler)
-  {
-    this.processTemplateToWriter(templateString, params, lambdas, new Handler<Writer>()
-    {
-      @Override
-      public void handle(Writer w)
-      {
-        handler.handle(w == null ? null : w.toString());
-      }
-    });
+    this.processTemplateToWriter(templateString, params, w -> handler.handle(w == null ? null : w.toString()));
   }
 
   @Deprecated
   public void processTemplateToWriter(String templateString, JsonObject params, final Handler<Writer> handler)
   {
-    this.getTemplate(templateString, new Handler<Template>()
-    {
-      @Override
-      public void handle(Template t)
-      {
-        processTemplate(t, params, handler);
-      }
-    });
-  }
-
-  public void processTemplateToWriter(String templateString, JsonObject params,  Map<String, Mustache.Lambda> lambdas,
-                                      final Handler<Writer> handler)
-  {
-    this.getTemplate(templateString, new Handler<Template>()
-    {
-      @Override
-      public void handle(Template t)
-      {
-        processTemplate(t, params, lambdas, handler);
-      }
-    });
-  }
-
-  protected void processTemplate(Template t, JsonObject params, Map<String, Mustache.Lambda> lambdas, final Handler<Writer> handler) {
-    final JsonObject ctxParams = (params == null) ? new JsonObject() : params.copy();
-    final Map<String, Object> ctx = JsonUtils.convertMap(ctxParams);
-    ctx.putAll(lambdas);
-    applyTemplate(t, ctx, handler);
+    this.getTemplate(templateString, t -> processTemplate(t, params, handler));
   }
 
   @Deprecated
@@ -149,13 +94,38 @@ public class TemplateProcessor
     applyTemplate(t, ctx, handler);
   }
 
-  protected void getTemplate(String templateString, final Handler<Template> handler)
-  {
+  @Deprecated
+  protected void getTemplate(String templateString, final Handler<Template> handler) {
     handler.handle(compiler.compile(templateString));
+  }
+
+  protected void getTemplate(ProcessTemplateContext context, final Handler<Template> handler) {
+    if(context.reader() == null) {
+      handler.handle(compiler.defaultValue(context.defaultValue())
+              .escapeHTML(context.escapeHtml())
+              .compile(context.templateString()));
+    } else {
+      handler.handle(compiler.defaultValue(context.defaultValue())
+              .escapeHTML(context.escapeHtml())
+              .compile(context.reader()));
+    }
+  }
+
+
+  public void processTemplate(ProcessTemplateContext templateContext, Template template, Handler<Writer> handler) {
+    final JsonObject ctxParams = (templateContext.params() == null) ? new JsonObject() : templateContext.params().copy();
+    final Map<String, Object> ctx = JsonUtils.convertMap(ctxParams);
+    applyLambdas(templateContext, ctx);
+    applyTemplate(template, ctx, handler);
+  }
+
+  public void processTemplate(ProcessTemplateContext templateContext, Handler<Writer> handler) {
+      getTemplate(templateContext, h -> processTemplate(templateContext, h, handler));
   }
 
 
   // ================================================ PRIVATE UTILS ===============================================
+
 
   private void applyTemplate(Template t, Map<String, Object> ctx, Handler<Writer> handler) {
     if (t != null) {
@@ -172,11 +142,13 @@ public class TemplateProcessor
     }
   }
 
-  private void applyLambdas(Map<String, Object> context)
-  {
-    for(Map.Entry<String, Mustache.Lambda> entry : this.templateLambdas.entrySet())
-    {
-      context.put(entry.getKey(), entry.getValue());
-    }
+  private void applyLambdas(ProcessTemplateContext templateContext, Map<String, Object> ctx) {
+      ctx.putAll(templateContext.lambdas());
   }
+
+  @Deprecated
+  private void applyLambdas(Map<String, Object> context) {
+      context.putAll(this.templateLambdas);
+  }
+
 }


### PR DESCRIPTION
# Description

Les TemplateProcessor largement utilisés dans le code ne sont pas thread safe au niveau des Lambda. On pourrait donc avoir des mélanges entre les paramètres de plusieurs utilisateurs lors de la génération de mail / notification / carte timeline etc… entre la langue, l’host, le thème ou le domaine => refactoring partiel pour corriger le problème. On conserve les anciennes API pour la retrocompatibilité avec les divers modules

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4672

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)