### PR TITLE
Fix impuls 6155 enforce objectstorage compliance

### DIFF
--- a/src/main/java/fr/wseduc/webutils/http/UriEncoder.java
+++ b/src/main/java/fr/wseduc/webutils/http/UriEncoder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © Open Digital Education, 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.wseduc.webutils.http;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Percent encoding as RFC 3986 defines it, which is what AWS SigV4 canonicalisation requires and what
+ * {@link java.net.URLEncoder} does not provide: URLEncoder emits {@code application/x-www-form-urlencoded},
+ * where a space becomes {@code +}, {@code ~} becomes {@code %7E} and {@code *} is left untouched. Each of
+ * those diverges from the form the server recomputes — a wrong key for the first, SignatureDoesNotMatch for
+ * the other two.
+ */
+public class UriEncoder {
+
+	/** Uppercase, as AWS requires of the hexadecimal value of an encoded byte. */
+	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+	/**
+	 * Encodes a value meant to sit inside a single URI component — a query string value, or one path segment
+	 * taken alone. Everything outside the unreserved set is percent encoded, {@code /} included.
+	 */
+	public static String encode(String value) {
+		return encode(value, false);
+	}
+
+	/**
+	 * Encodes a whole path: same rules as {@link #encode(String)}, except {@code /} is left as the separator
+	 * it is. Empty segments, leading and trailing separators included, are preserved as they are.
+	 */
+	public static String encodePath(String path) {
+		return encode(path, true);
+	}
+
+	/**
+	 * The exact inverse of {@link #encode(String)} and {@link #encodePath(String)}. Unlike
+	 * {@link java.net.URLDecoder}, a {@code +} decodes to a literal plus rather than to a space, and an
+	 * incomplete or malformed escape is left untouched instead of raising.
+	 */
+	public static String decode(String value) {
+		if (value == null) {
+			return null;
+		}
+		final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		final ByteArrayOutputStream decoded = new ByteArrayOutputStream(bytes.length);
+		for (int i = 0; i < bytes.length; i++) {
+			if (bytes[i] == '%' && i + 2 < bytes.length) {
+				final int high = Character.digit(bytes[i + 1], 16);
+				final int low = Character.digit(bytes[i + 2], 16);
+				if (high >= 0 && low >= 0) {
+					decoded.write((high << 4) + low);
+					i += 2;
+					continue;
+				}
+			}
+			decoded.write(bytes[i]);
+		}
+		return new String(decoded.toByteArray(), StandardCharsets.UTF_8);
+	}
+
+	private static String encode(String value, boolean keepSeparator) {
+		if (value == null) {
+			return null;
+		}
+		final StringBuilder encoded = new StringBuilder(value.length());
+		for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+			if (isUnreserved(b) || (keepSeparator && b == '/')) {
+				encoded.append((char) b);
+			} else {
+				encoded.append('%').append(HEX[(b >> 4) & 0xF]).append(HEX[b & 0xF]);
+			}
+		}
+		return encoded.toString();
+	}
+
+	/** The unreserved set of RFC 3986 §2.3. A byte of a multi byte UTF-8 sequence is negative, so encoded. */
+	private static boolean isUnreserved(byte b) {
+		return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+				|| b == '-' || b == '.' || b == '_' || b == '~';
+	}
+
+}

--- a/src/main/java/fr/wseduc/webutils/security/AWS4Signature.java
+++ b/src/main/java/fr/wseduc/webutils/security/AWS4Signature.java
@@ -22,6 +22,8 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
@@ -46,7 +48,7 @@ public class AWS4Signature {
         final StringBuilder canonicalRequest = new StringBuilder()
                 .append(httpMethod).append("\n")
                 .append(canonicalUri).append("\n")
-                .append(canonicalQueryString).append("\n");
+                .append(canonicalQueryString(canonicalQueryString)).append("\n");
 
         final String hashPayload = (payloadSha256 != null ? payloadSha256: EMPTY_PAYLOAD_SHA256);
 
@@ -103,6 +105,64 @@ public class AWS4Signature {
         return canonical;
     }
 
+    /**
+     * The authority Vert.x will actually write in the {@code Host} header, which is the value that has to be
+     * signed. {@link HttpClientRequest#getHost()} alone drops the port, while Vert.x appends it as soon as it
+     * is not the default one for the scheme — signing the bare host against an endpoint on a non standard port
+     * (MinIO, an internal gateway) yields SignatureDoesNotMatch.
+     */
+    public static String authority(HttpClientRequest request) {
+        return authority(request.getHost(), request.getPort(), request.connection().isSsl());
+    }
+
+    /**
+     * Same rule as {@code HttpClientRequestBase.authority()}, kept here so that the signed value and the one
+     * put on the wire cannot drift apart.
+     */
+    public static String authority(String host, int port, boolean ssl) {
+        if (port < 0 || (port == 80 && !ssl) || (port == 443 && ssl)) {
+            return host;
+        }
+        return host + ":" + port;
+    }
+
+    /**
+     * The {@code CanonicalQueryString} of SigV4: parameters split on {@code &}, each given an explicit
+     * {@code =}, and the whole sorted by parameter name — then by value for a repeated name.
+     * <p>
+     * Values are passed through exactly as they already sit in the URI: they are what goes on the wire, and
+     * re-encoding them here would turn every {@code %} into {@code %25}. Encoding stays the caller's job,
+     * ordering is ours — a query built in any other order used to sign against a canonical request the
+     * server never rebuilds the same way, and answer SignatureDoesNotMatch.
+     */
+    public static String canonicalQueryString(String query) {
+        if (query == null || query.isEmpty()) {
+            return "";
+        }
+        final List<String[]> params = new ArrayList<>();
+        for (String param : query.split("&")) {
+            if (param.isEmpty()) {
+                continue;
+            }
+            final int separator = param.indexOf('=');
+            params.add(separator < 0
+                    ? new String[] { param, "" }
+                    : new String[] { param.substring(0, separator), param.substring(separator + 1) });
+        }
+        params.sort((a, b) -> {
+            final int byName = a[0].compareTo(b[0]);
+            return byName != 0 ? byName : a[1].compareTo(b[1]);
+        });
+        final StringBuilder canonical = new StringBuilder();
+        for (String[] param : params) {
+            if (canonical.length() > 0) {
+                canonical.append("&");
+            }
+            canonical.append(param[0]).append("=").append(param[1]);
+        }
+        return canonical.toString();
+    }
+
     public static String byteArrayToHex(byte[] a) {
         final StringBuilder sb = new StringBuilder(a.length * 2);
         for(byte b: a)
@@ -117,7 +177,7 @@ public class AWS4Signature {
         final Instant instant = Instant.now();
         final String now = DATETIME_FORMAT.format(instant);
         final MultiMap canonicalHeaders = MultiMap.caseInsensitiveMultiMap();
-        canonicalHeaders.add("host", request.getHost());
+        canonicalHeaders.add("host", authority(request));
         // Every x-amz-* header carried by the request MUST be signed: S3 implementations reject the
         // request otherwise, with AccessDenied / HeadersNotSigned naming the offending header. This
         // covers object metadata (x-amz-meta-*), SSE-C keys and copy-source headers alike.

--- a/src/test/java/fr/wseduc/webutils/http/UriEncoderTest.java
+++ b/src/test/java/fr/wseduc/webutils/http/UriEncoderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © Open Digital Education, 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.wseduc.webutils.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UriEncoderTest {
+
+	@Test
+	public void unreservedCharactersAreLeftAlone() {
+		assertEquals("azAZ09-._~", UriEncoder.encode("azAZ09-._~"));
+	}
+
+	/**
+	 * The three divergences of {@link java.net.URLEncoder} that motivate this encoder: a space encoded as
+	 * {@code +} stores a wrong key, and {@code ~} / {@code *} encoded the wrong way have the server recompute
+	 * a different canonical request — SignatureDoesNotMatch.
+	 */
+	@Test
+	public void encodesWhatUrlEncoderGetsWrong() {
+		assertEquals("a%20b.pdf", UriEncoder.encode("a b.pdf"));
+		assertEquals("~", UriEncoder.encode("~"));
+		assertEquals("%2A", UriEncoder.encode("*"));
+		assertEquals("%2B", UriEncoder.encode("+"));
+	}
+
+	/** AWS requires the hexadecimal value of an encoded byte to be uppercase. */
+	@Test
+	public void escapesUseUppercaseHex() {
+		assertEquals("%3A%2F%3F%23%5B%5D%40", UriEncoder.encode(":/?#[]@"));
+	}
+
+	@Test
+	public void nonAsciiIsEncodedAsUtf8() {
+		assertEquals("%C3%A9l%C3%A8ve.pdf", UriEncoder.encode("élève.pdf"));
+	}
+
+	@Test
+	public void separatorIsEncodedInAValueAndKeptInAPath() {
+		assertEquals("a%2Fb", UriEncoder.encode("a/b"));
+		assertEquals("a/b%20c/d~e", UriEncoder.encodePath("a/b c/d~e"));
+	}
+
+	/** A segment split on {@code /} would silently drop the trailing one, and with it a directory marker. */
+	@Test
+	public void encodePathPreservesEmptySegments() {
+		assertEquals("/a/b/", UriEncoder.encodePath("/a/b/"));
+	}
+
+	@Test
+	public void decodeIsTheInverseOfEncode() {
+		final String key = "dossier privé/rapport final (v2)*~.pdf";
+		assertEquals(key, UriEncoder.decode(UriEncoder.encodePath(key)));
+	}
+
+	/** Where {@link java.net.URLDecoder} would hand back a space, and corrupt an opaque identifier. */
+	@Test
+	public void decodeKeepsPlusLiteral() {
+		assertEquals("a+b", UriEncoder.decode("a+b"));
+	}
+
+	@Test
+	public void decodeLeavesAMalformedEscapeUntouched() {
+		assertEquals("100% sûr", UriEncoder.decode("100%%20s%C3%BBr"));
+		assertEquals("%2", UriEncoder.decode("%2"));
+	}
+
+}

--- a/src/test/java/fr/wseduc/webutils/security/AWS4SignatureRequestTest.java
+++ b/src/test/java/fr/wseduc/webutils/security/AWS4SignatureRequestTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © Open Digital Education, 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.wseduc.webutils.security;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.RequestOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Signs a real request against a real server, and recomputes the signature from what the server actually
+ * received. Where {@code AlgorithmTest} pins the algorithm on fixed inputs, this pins the wiring: which
+ * {@code host} value and which query string {@link AWS4Signature#sign(io.vertx.core.http.HttpClientRequest,
+ * String, String, String, String)} feeds the canonical request.
+ * <p>
+ * The two defects it guards against are silent under AWS on 443 with a single query parameter, which is why
+ * they went unnoticed: a bare {@code host} only breaks on an endpoint with a non standard port (MinIO, an
+ * internal gateway), and an unsorted query only breaks on the routes carrying several parameters.
+ */
+public class AWS4SignatureRequestTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+
+    /** An encoded key, as {@code S3Client.encodeUrlPath} produces. Vert.x hands it to the signer verbatim. */
+    private static final String PATH = "/bucket/dossier%20priv%C3%A9/a%20b.pdf";
+    /** Deliberately not in SigV4 order: the signer has to sort it, the wire keeps it as it is. */
+    private static final String WIRE_QUERY = "uploadId=a%2Bb%3D%3D&partNumber=1";
+    private static final String CANONICAL_QUERY = "partNumber=1&uploadId=a%2Bb%3D%3D";
+
+    private static final DateTimeFormatter AMZ_DATE = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
+
+    private Vertx vertx;
+    private HttpServer server;
+    private HttpClient client;
+
+    private final CompletableFuture<MultiMap> received = new CompletableFuture<>();
+    private final AtomicReference<String> receivedUri = new AtomicReference<>();
+
+    @Before
+    public void setUp() throws Exception {
+        vertx = Vertx.vertx();
+        server = await(vertx.createHttpServer()
+                .requestHandler(request -> {
+                    receivedUri.set(request.uri());
+                    // Copied: the server request, and its header map, are recycled once the handler returns.
+                    received.complete(MultiMap.caseInsensitiveMultiMap().addAll(request.headers()));
+                    request.response().setStatusCode(200).end();
+                })
+                .listen(0));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (vertx != null) {
+            await(vertx.close());
+        }
+    }
+
+    @Test
+    public void signsTheAuthorityAndTheSortedQueryTheServerReceives() throws Exception {
+        final int port = server.actualPort();
+        // The premise of the whole test: an ephemeral port is never the default one of the scheme.
+        assertNotEquals(80, port);
+        assertNotEquals(443, port);
+
+        // Same shape as ResilientHttpClient / S3Client: the port lives on the client options, the request
+        // itself only carries a host — which is exactly how the missing port went unnoticed.
+        client = vertx.createHttpClient(new HttpClientOptions()
+                .setDefaultHost("localhost")
+                .setDefaultPort(port));
+        await(client.request(new RequestOptions()
+                        .setMethod(HttpMethod.PUT)
+                        .setHost("localhost")
+                        .setURI(PATH + "?" + WIRE_QUERY))
+                .compose(request -> {
+                    try {
+                        AWS4Signature.sign(request, REGION, ACCESS_KEY, SECRET_KEY, null);
+                    } catch (Exception e) {
+                        return Future.failedFuture(e);
+                    }
+                    return request.send();
+                }));
+
+        final MultiMap headers = received.get(10, TimeUnit.SECONDS);
+        final String authority = headers.get("Host");
+        final String amzDate = headers.get("x-amz-date");
+        final String signature = signatureOf(headers.get("Authorization"));
+
+        // What Vert.x put on the wire, and what therefore has to be signed.
+        assertEquals("localhost:" + port, authority);
+        assertEquals("host;x-amz-content-sha256;x-amz-date", signedHeadersOf(headers.get("Authorization")));
+        // The request is signed, not rewritten: the query reaches the server in the order it was built.
+        assertEquals(PATH + "?" + WIRE_QUERY, receivedUri.get());
+
+        // The pin: the signature that travelled is the one over the authority the server received, and over
+        // the query sorted as SigV4 wants it.
+        assertEquals(signatureFor(authority, CANONICAL_QUERY, amzDate), signature);
+
+        // And not the signature the bare host would have produced: without this, going back to
+        // request.getHost() would leave the suite green.
+        assertNotEquals(signatureFor("localhost", CANONICAL_QUERY, amzDate), signature);
+        // The sort is pinned by the assertion above, not here: the query reached the server unsorted, so a
+        // signer that stopped sorting would no longer match CANONICAL_QUERY. What is left to check is that
+        // the query takes part in the canonical request at all.
+        assertNotEquals(signatureFor(authority, "partNumber=2&uploadId=a%2Bb%3D%3D", amzDate), signature);
+    }
+
+    /** Recomputes a signature straight from the specification, on the values the server reported. */
+    private static String signatureFor(String host, String canonicalQuery, String amzDate) throws Exception {
+        final MultiMap canonicalHeaders = MultiMap.caseInsensitiveMultiMap();
+        canonicalHeaders.add("host", host);
+        canonicalHeaders.add("x-amz-content-sha256", AWS4Signature.EMPTY_PAYLOAD_SHA256);
+        canonicalHeaders.add("x-amz-date", amzDate);
+        return AWS4Signature.sign("PUT", PATH, canonicalQuery, canonicalHeaders,
+                REGION, ACCESS_KEY, SECRET_KEY, null, instantOf(amzDate));
+    }
+
+    /**
+     * The signed instant, read back from the header the signer posted. {@code x-amz-date} is second
+     * precision, and the signature derives from that same truncated value, so this is exact.
+     */
+    private static Instant instantOf(String amzDate) {
+        return LocalDateTime.parse(amzDate, AMZ_DATE).toInstant(ZoneOffset.UTC);
+    }
+
+    private static String signatureOf(String authorization) {
+        return valueOf(authorization, "Signature=");
+    }
+
+    private static String signedHeadersOf(String authorization) {
+        return valueOf(authorization, "SignedHeaders=");
+    }
+
+    private static String valueOf(String authorization, String field) {
+        final int from = authorization.indexOf(field) + field.length();
+        final int to = authorization.indexOf(',', from);
+        return to < 0 ? authorization.substring(from) : authorization.substring(from, to);
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/test/java/fr/wseduc/webutils/test/AlgorithmTest.java
+++ b/src/test/java/fr/wseduc/webutils/test/AlgorithmTest.java
@@ -174,6 +174,24 @@ public class AlgorithmTest {
 		assertNotEquals(plainSignature, encodedSignature);
 	}
 
+	/**
+	 * Pins the {@code host} value that gets signed. Vert.x writes {@code host:port} in the Host header as soon
+	 * as the port is not the default one for the scheme, so that is what has to be signed — an endpoint on a
+	 * non standard port (MinIO, an internal gateway) answers SignatureDoesNotMatch otherwise.
+	 */
+	@Test
+	public void aws4SignedHostCarriesANonDefaultPort() {
+		assertEquals("minio.internal:9000", AWS4Signature.authority("minio.internal", 9000, false));
+		assertEquals("minio.internal:9000", AWS4Signature.authority("minio.internal", 9000, true));
+		// The default port of the scheme in use is left out, as Vert.x leaves it out.
+		assertEquals("s3.amazonaws.com", AWS4Signature.authority("s3.amazonaws.com", 443, true));
+		assertEquals("s3.internal", AWS4Signature.authority("s3.internal", 80, false));
+		// But 443 in clear and 80 over TLS are not: Vert.x sends them, so they are signed.
+		assertEquals("s3.internal:443", AWS4Signature.authority("s3.internal", 443, false));
+		assertEquals("s3.internal:80", AWS4Signature.authority("s3.internal", 80, true));
+		assertEquals("s3.internal", AWS4Signature.authority("s3.internal", -1, false));
+	}
+
 	@Test
 	public void aws4HeaderValuesAreTrimmed() throws Exception {
 		final MultiMap padded = MultiMap.caseInsensitiveMultiMap();
@@ -188,6 +206,48 @@ public class AlgorithmTest {
 		assertEquals(
 				AWS4Signature.sign("PUT", "/test.txt", "", tidy, "us-east-1", "key", "secret", null, instant),
 				AWS4Signature.sign("PUT", "/test.txt", "", padded, "us-east-1", "key", "secret", null, instant));
+	}
+
+	/**
+	 * SigV4 signs the parameters sorted by name, whatever order they go on the wire in. Left to the caller,
+	 * this held only by luck on every route carrying more than one parameter.
+	 */
+	@Test
+	public void aws4CanonicalQueryStringIsSortedByName() {
+		assertEquals("partNumber=1&uploadId=abc",
+				AWS4Signature.canonicalQueryString("uploadId=abc&partNumber=1"));
+		assertEquals("continuation-token=t&list-type=2&prefix=x",
+				AWS4Signature.canonicalQueryString("list-type=2&prefix=x&continuation-token=t"));
+		// A repeated name is ordered on its value.
+		assertEquals("k=a&k=b", AWS4Signature.canonicalQueryString("k=b&k=a"));
+	}
+
+	/** A parameter with no value still carries its {@code =}, as {@code ?uploads} does. */
+	@Test
+	public void aws4CanonicalQueryStringAlwaysCarriesTheEquals() {
+		assertEquals("uploads=", AWS4Signature.canonicalQueryString("uploads"));
+		assertEquals("uploads=", AWS4Signature.canonicalQueryString("uploads="));
+		assertEquals("", AWS4Signature.canonicalQueryString(""));
+		assertEquals("", AWS4Signature.canonicalQueryString(null));
+	}
+
+	/**
+	 * Values arrive already percent encoded — they are what the URI carries. Encoding them a second time
+	 * here would sign {@code %2520} against a wire value of {@code %20}.
+	 */
+	@Test
+	public void aws4CanonicalQueryStringLeavesEncodedValuesAlone() {
+		assertEquals("prefix=dossier%20priv%C3%A9%2F",
+				AWS4Signature.canonicalQueryString("prefix=dossier%20priv%C3%A9%2F"));
+		// An opaque uploadId holding an encoded + keeps it: decoding it would corrupt the token.
+		assertEquals("uploadId=a%2Bb%3D%3D", AWS4Signature.canonicalQueryString("uploadId=a%2Bb%3D%3D"));
+	}
+
+	/** Already canonical in, unchanged out — the signature of a compliant call site does not move. */
+	@Test
+	public void aws4CanonicalQueryStringIsIdempotent() {
+		final String canonical = AWS4Signature.canonicalQueryString("uploadId=abc&partNumber=1");
+		assertEquals(canonical, AWS4Signature.canonicalQueryString(canonical));
 	}
 
 }


### PR DESCRIPTION
Modification d'object storage pour être en conformité avec la spéc.
[IMPULS-6155](https://edifice-community.atlassian.net/browse/IMPULS-6155)

[IMPULS-6155]: https://edifice-community.atlassian.net/browse/IMPULS-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ